### PR TITLE
責務単位のcommitを時系列で回収するルールを追加

### DIFF
--- a/.agents/skills/github-delivery/SKILL.md
+++ b/.agents/skills/github-delivery/SKILL.md
@@ -29,8 +29,11 @@ description: "リポジトリ変更を、主Issue、専用branch、論理的なc
 ## 3. 実装とcommit
 
 - 真のblockerがない限り、調査、実装、検証、配送を同じtaskで継続する。
+- 実装前に、受け入れ条件と依存関係から予定commitの責務、関連test・文書、実装順序を決める。責務の境界が実装中に変わった場合は、次の編集前に計画を更新する。
 - 目的を満たす最小十分な差分を作り、非対象を先行実装しない。
 - commitは独立してreview・revertできる一つの論理的責務または受け入れ条件の単位にする。関連test、文書、schema、生成物は同じcommitへ含める。
+- 一つの責務の実装・関連test・文書・検証が完了したら、次の独立責務を編集する前にstage確認とcommitを完了する。複数責務を共有作業ツリーへ蓄積し、最後に全差分を再読して後付け分解しない。
+- サブエージェントの完了報告を受けたら、メインが担当fileと差分をreviewし、その責務だけを上記の時点でcommitへ回収する。他担当の未完了差分はstageしない。
 - `git add .` と `git add -A` を使わず、stageするpathを明示する。
 - commit前にstaged file名、staged diff、`git diff --check`、secret・実データ・無関係差分の不在を確認する。
 - commit messageは変更の責務を短く表す。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@
 - ソースコード変更依頼は、主Issueの確定、専用branch、論理的なcommit、push、非ドラフトPR、latest headのCI、GitHub上のreview対応、未解決thread確認、mergeability確認までの通常配送を行う権限を含みます。
 - 通常配送の順序は [`.agents/skills/github-delivery/SKILL.md`](.agents/skills/github-delivery/SKILL.md)、完了条件は [`docs/ai-governance/03-evidence-and-completion-gates.md`](docs/ai-governance/03-evidence-and-completion-gates.md) を正本とします。
 - commitは独立してreview・revertできる一つの論理的責務または受け入れ条件の単位にします。関連するtest、文書、生成物は同じcommitへ含めます。
+- 複数工程は着手前にcommitの責務と順序を決め、各責務の実装・関連test・文書・検証が完了した時点で、次の独立責務へ進む前にcommitします。複数の独立責務を未commitのまま蓄積し、最後に全差分を後付けで分解しません。
+- 共有作業ツリーのサブエージェント差分は、担当した責務の完了ごとにメインがfile範囲と内容をreviewしてcommitへ回収します。作業時間、行数、担当者だけを理由にcommitを分割・一括化しません。
 - stage対象はpathを明示し、commit前にstaged file名、staged diff、`git diff --check`、secret・実データ・無関係差分の不在を確認します。
 - `Closes #N` は対象Issueを完全に解決し、merge時のcloseを意図する場合だけ使います。部分対応や関連付けは `Refs #N` を使います。
 - merge、Issue・PRのclose、release、deploy、force-push、公開済み履歴の書換え、破壊的操作は通常配送に含めません。対象を特定した別の明示指示がある場合だけ実行します。

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ oak_logを4個集めて、ここへ戻ってきて。
 | 区分      | 必須設定                                                 | 既定設定                                                                         |
 | --------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Minecraft | `MINECRAFT_HOST`、`MINECRAFT_USERNAME`、`OWNER_USERNAME` | port `25565`、auth `microsoft`、version `1.21.11`                                |
-| OpenAI    | `OPENAI_API_KEY`                                         | model `gpt-5.6-luna`                                                              |
+| OpenAI    | `OPENAI_API_KEY`                                         | model `gpt-5.6-luna`                                                             |
 | 永続化    | なし                                                     | `DATABASE_PATH=data/companion.sqlite`                                            |
 | 安全上限  | なし                                                     | 移動距離、採取数、timeout、retry、追従距離、空腹しきい値は `.env.example` を参照 |
 | live E2E  | なし                                                     | `LIVE_E2E_CONFIRMED=false`。許可済みtest worldでだけ`true`にする                 |


### PR DESCRIPTION
## 変更

- 複数工程の着手前に、commit責務・関連test/文書・実装順を決める
- 各責務の実装・test・文書・検証完了時に、次の独立責務へ進む前にcommitする
- 共有作業ツリーのサブエージェント差分を、担当完了ごとにメインがreviewして回収する
- 複数責務を最後まで蓄積して後付け分解する運用と、時間・行数・担当者だけによる分割を禁止する

共通原則はルート `AGENTS.md`、実行順序はGitHub配送Skillへ置き、Claude Code / Cursor adapterへ本文を複製していません。

## 検証

- `bash -n scripts/verify-agent-harness.sh`
- `python3 -m py_compile scripts/validate_agent_frontmatter.py`
- `bash scripts/verify-agent-harness.sh`
- instruction budget: `AGENTS.md` 71行 / 7,161 bytes、GitHub配送Skill 65行 / 6,509 bytes
- `git diff --check`
- staged file / diff / 公開安全性確認
- latest headのagent harness / Node 22 / Node 24 CI成功

Product qualityのformat gateで検出された既存README表の空白1文字も、ルール変更と混ぜず独立したformat-only commitで正規化しました。

Closes #8